### PR TITLE
add callback to socket.send() to avoid data loss after socket.end()

### DIFF
--- a/lib/nossock.js
+++ b/lib/nossock.js
@@ -74,7 +74,7 @@ var Nossock = function(socket) {
     /**
      * Send message
      */
-    this.send = function(name, body) {
+    this.send = function(name, body, callback) {
 
         var isJson = ! (body instanceof Buffer);
         body = isJson ? new Buffer(JSON.stringify(body)) : body;
@@ -98,7 +98,11 @@ var Nossock = function(socket) {
         socket.write(b);
 
         // body ::= Buffer(bodyLen)
-        socket.write(body);
+        socket.write(body, function () {
+            if (callback) {
+                return callback();
+            }
+        });
     };
 
 


### PR DESCRIPTION
Code example:
```
socket.send('msgName', msg);
socket.end();
```

socket.send() function use origin socket.write() function which does not guarantee that all the data is flushed to kernel buffer and socket.end() function can interrupt sending data which in the user memory at the moment.

To avoid this, you can use 'drain' socket event or pass a callback to socket.write() function

